### PR TITLE
feat: update header color when intro video plays

### DIFF
--- a/client/components/Header.vue
+++ b/client/components/Header.vue
@@ -1,5 +1,5 @@
 <template>
-  <header class="header">
+  <header :class="['header', { 'header--white': isPlaying }]">
     <div class="header__container">
       <div class="header__body">
         <div :class="['burger-wrapper', { open: openLanguages }]" @click="toggleLanguages">
@@ -312,6 +312,12 @@ ul li {
     @media (max-width: 992px) {
       color: white;
     }
+  }
+}
+
+.header--white {
+  .menu__link {
+    color: #fff;
   }
 }
 .languages {

--- a/client/components/Intro.vue
+++ b/client/components/Intro.vue
@@ -136,7 +136,7 @@ export default {
       openContact: false,
       observer: null,
       isVideoLoaded: false,
-      isPlayingisPlayingisPlaying: false,
+      isPlaying: false,
       isMuted: true,
       isStopped: false,
     };
@@ -148,6 +148,7 @@ export default {
         this.$refs.bgVideo.muted = this.isMuted;
         this.$refs.bgVideo.play();
         this.isPlaying = true;
+        this.$emit('isPlaying', this.isPlaying);
       }
     },
     togglePlay() {
@@ -157,10 +158,7 @@ export default {
         this.isVideoLoaded = true;
         this.$refs.bgVideo.play();
         this.isPlaying = true;
-        return;
-      }
-      if (this.isPlaying) {
-        if (!this.$refs.bgVideo) return;
+      } else if (this.isPlaying) {
         this.$refs.bgVideo.pause();
         this.$refs.bgVideo.currentTime = 0;
         this.isPlaying = false;
@@ -168,8 +166,9 @@ export default {
         this.isStopped = true;
       } else {
         this.$refs.bgVideo.play();
+        this.isPlaying = true;
       }
-      this.isPlaying = !this.isPlaying;
+      this.$emit('isPlaying', this.isPlaying);
     },
     toggleMute() {
       if (!this.$refs.bgVideo) return;

--- a/client/pages/index.vue
+++ b/client/pages/index.vue
@@ -2,7 +2,7 @@
   <div>
     <Header :links="links" :isPlaying="isVideoPlaying" />
     <main class="main">
-      <Intro id="home" url="#projects" :intro="intro" @isPlaying="isVideoPlaying" />
+      <Intro id="home" url="#projects" :intro="intro" @isPlaying="setVideoPlaying" />
       <About id="about" :aboutUs="aboutUs" />
       <!-- <Ehs id="ehs" /> -->
       <product-service id="products-services" :items="products" />
@@ -182,7 +182,7 @@ export default {
         console.error(error);
       }
     },
-    isVideoPlaying(value) {
+    setVideoPlaying(value) {
       this.isVideoPlaying = value;
     },
   },


### PR DESCRIPTION
## Summary
- emit intro video play state and broadcast to header
- adjust header text color to white when video plays
- fix index event handler naming

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a40a367ff083258f6d7a2c7f07ce8d