### PR TITLE
fix: remove empty style blocks causing postcss error

### DIFF
--- a/client/components/adminka/AdminTagline.vue
+++ b/client/components/adminka/AdminTagline.vue
@@ -113,4 +113,3 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped></style>

--- a/client/components/base/BaseIcon.vue
+++ b/client/components/base/BaseIcon.vue
@@ -19,4 +19,3 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped></style>

--- a/client/layouts/empty.vue
+++ b/client/layouts/empty.vue
@@ -6,4 +6,3 @@
 export default {};
 </script>
 
-<style lang="scss" scoped></style>


### PR DESCRIPTION
## Summary
- remove empty `<style>` blocks from layout and components that triggered `PostCSS received undefined` errors during build

## Testing
- `npm run lint` *(fails: no-unused-vars, no-undef, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5a33cbca88325811734d32c22c0ee