### PR TITLE
Use slugs for public-facing routes

### DIFF
--- a/client/api/home.api.js
+++ b/client/api/home.api.js
@@ -4,8 +4,8 @@ export const GET_ABOUT = () => request({ url: `about`, method: "PATCH" });
 
 export const GET_PRODUCTS = () =>
   request({ url: `products-services`, method: "PATCH" });
-export const GET_PRODUCTS_ONE = ({ data }) =>
-  request({ url: `services/find/${data.id}`, method: "POST" });
+export const GET_PRODUCTS_ONE = ({ slug }) =>
+  request({ url: `services/find/${slug}`, method: "POST" });
 
 export const GET_PRODUCTS_LIMIT = () =>
   request({ url: `services/`, method: "PATCH" });
@@ -14,14 +14,14 @@ export const GET_HOME = () => request({ url: `home`, method: "PATCH" });
 
 export const GET_NEWS = ({ limit, page }) => request({ url: `news`, method: "PATCH", params:{limit, page } });
 export const GET_NEWS_ALL = ({ limit, page }) => request({ url: `news/all`, method: "POST", data: { limit, page } });
-export const GET_NEWS_ID = ({ data }) =>
-  request({ url: `news/one/${data.newsId}`, method: "GET" });
+export const GET_NEWS_ID = ({ slug }) =>
+  request({ url: `news/one/${slug}`, method: "GET" });
 
 export const GET_ABOUT_LIMIT = () =>
   request({ url: `projects/all`, method: "POST" });
 export const GET_PROJECTS = () => request({ url: `projects`, method: "PATCH" });
-export const GET_PROJECT_ONE = ({ data }) =>
-  request({ url: `projects/one/${data.projectId}`, method: "POST" });
+export const GET_PROJECT_ONE = ({ slug }) =>
+  request({ url: `projects/one/${slug}`, method: "POST" });
 
 export const POST_MAIL = ({ data }) =>
   request({ url: `mail`, method: "POST", data: data });

--- a/client/components/News.vue
+++ b/client/components/News.vue
@@ -5,8 +5,8 @@
         <div class="news__left-items">
           <!-- class="news__left-item" -->
           <div v-for="item in news.news" :key="item.newsId">
-            <!-- @click="$router.push(localeLocation(`/news/${item.newsId}`))" -->
-            <a :href="`/${$i18n.locale}/news/${item.newsId}`" class="news__left-item">
+            <!-- @click="$router.push(localeLocation(`/news/${item.slug}`))" -->
+            <a :href="`/${$i18n.locale}/news/${item.slug}`" class="news__left-item">
               <div class="news__left-item-image">
                 <img :src="`${imageURL}${item?.image}`" alt="" />
               </div>
@@ -26,7 +26,7 @@
           {{ $t('seeAll') }}
         </button>
       </div>
-      <a :href="`${$i18n.locale}/news/${news?.mainNews?.newsId}`">
+      <a :href="`${$i18n.locale}/news/${news?.mainNews?.slug}`">
         <div class="news__center">
           <div class="news__center-image">
             <img :src="`${imageURL}${news?.mainNews?.image}`" alt="" />

--- a/client/components/ProductService.vue
+++ b/client/components/ProductService.vue
@@ -3,8 +3,8 @@
     <h1 class="services__title">{{ $t('productsServices') }}</h1>
     <div class="services__row" ref="images">
       <div class="services__item" v-for="item in items?.services" :key="item?.id">
-        <!-- @click="$router.push(localeLocation(`/products-services/${item?.id}`))" -->
-        <a :href="`/products-services/${item?.id}`">
+        <!-- @click="$router.push(localeLocation(`/products-services/${item?.slug}`))" -->
+        <a :href="`/products-services/${item?.slug}`">
           <div class="services__content">
             <div class="services__content-logo">
               <img :src="`${imageURL}${item?.logo}`" alt="" />
@@ -19,7 +19,7 @@
         class="services__item"
         v-for="item in items?.products"
         :key="item?.id"
-        @click="$router.push(localeLocation(`/products-services/${item?.id}`))"
+        @click="$router.push(localeLocation(`/products-services/${item?.slug}`))"
       >
         <!-- <div class="services__image">
           <img :src="`${imageURL}${item?.images[0]}`" alt="" />

--- a/client/components/Projects.vue
+++ b/client/components/Projects.vue
@@ -5,8 +5,8 @@
     </div>
     <div class="projects__row" ref="images">
       <div class="projects__item" v-for="project in projects" :key="project.projectId">
-        <!-- @click="$router.push(localeLocation(`/projects/${project.projectId}`))" -->
-        <a :href="`/${$i18n.locale}/projects/${project.projectId}`" class="projects__item">
+        <!-- @click="$router.push(localeLocation(`/projects/${project.slug}`))" -->
+        <a :href="`/${$i18n.locale}/projects/${project.slug}`" class="projects__item">
           <div class="projects__image">
             <img :src="`${imageURL}${project?.cover}`" alt="" />
           </div>

--- a/client/pages/news/_slug.vue
+++ b/client/pages/news/_slug.vue
@@ -66,7 +66,7 @@ export default {
     async fetchNews() {
       try {
         const { data, statusCode } = await GET_NEWS_ID({
-          data: { newsId: this.$route.params.id },
+          slug: this.$route.params.slug,
         });
         if (statusCode) this.news = data;
         // console.log(this.news);

--- a/client/pages/news/index.vue
+++ b/client/pages/news/index.vue
@@ -11,8 +11,8 @@
     </div>
     <div class="news-page__items">
       <div v-for="item in news" :key="item.newsId">
-        <!-- @click="$router.push(`/news/${item.newsId}`)" -->
-        <a :href="`/news/${item.newsId}`" class="news-page__item">
+        <!-- @click="$router.push(`/news/${item.slug}`)" -->
+        <a :href="`/news/${item.slug}`" class="news-page__item">
           <div class="news-page__image">
             <img :src="`${imageURL}${item?.image}`" alt="" />
           </div>

--- a/client/pages/products-services/_slug.vue
+++ b/client/pages/products-services/_slug.vue
@@ -1,114 +1,79 @@
 <template>
-  <div class="projects-id" ref="aos">
-    <div class="projects-id__container">
-      <div class="projects-id__arrow">
+  <div class="products" ref="aos">
+    <div class="products__container">
+      <div class="products__arrow">
         <base-icon
           icon="arrowLeft"
           class="project-icon"
-          @clicked="$router.push(localeLocation(`/${$i18n.locale}/projects`))"
+          @clicked="$router.back(localeLocation(-1))"
         />
       </div>
-      <div class="projects-id__project">
-        <div class="projects-id__project-image" style="margin-right: 15px">
-          <!-- <img src="@/assets/img/mennan.svg" alt="" /> -->
-          <img
-            :src="`${imageURL}${project.cover}`"
-            alt=""
-            @click="openModal(`${imageURL}${project.cover}`)"
-          />
+      <div class="products__project">
+        <div class="products__project-image">
+          <img :src="`${imageURL}${product?.logo}`" alt="" />
         </div>
-        <div class="projects-id__project-content">
-          <p class="projects-id__project-text">
-            <span class="projects-id__project-span">{{ $t('company') }}:</span>
-            <span>
-              {{ project?.[translator('company')] }}
-            </span>
+        <div class="products__project-content">
+          <p class="products__project-text">
+            <!-- <span>Name:</span> -->
+            <!-- <span>{{ translateName(product) }}</span> -->
           </p>
-          <p class="projects-id__project-text">
-            <span class="projects-id__project-span">{{ $t('engineeringPeriod') }}:</span>
-            <span>
-              {{
-                new Date(project?.workDate).toLocaleString(translateLanguage(project), {
-                  month: 'long',
-                })
-              }}, {{ new Date(project?.workDate).getFullYear() }}
-            </span>
-            <span
-              v-if="
-                project?.endDate &&
-                new Date(project?.workDate).getMonth() !== new Date(project?.endDate).getMonth()
-              "
-            >
-              -
-              {{
-                new Date(project?.endDate).toLocaleString(translateLanguage(project), {
-                  month: 'long',
-                })
-              }}, {{ new Date(project?.endDate).getFullYear() }}
-            </span>
-          </p>
-          <p class="projects-id__project-text">
-            <span v-html="project[translator(`name`)]" style="font-weight: 600"></span>
-          </p>
+          <!-- <p class="products__project-text">
+            <span>Type:</span>
+            <span>{{ product?.type }}</span>
+          </p> -->
         </div>
       </div>
-      <div class="projects-id__description-wrapper">
-        <h1 class="projects-id__description-title">{{ $t('description') }}</h1>
+      <p style="color: #183a60; font-size: large; font-weight: 600; margin-bottom: 10px">
+        {{ product[translator('name')] }}
+      </p>
+      <div class="products__description-wrapper">
+        <h1 class="products__description-title">{{ $t('description') }}</h1>
+
         <p
-          class="projects-id__description-description"
-          v-html="project?.[translator(`description`)]"
+          class="products__description-description inner_description"
+          style="line-height: 2em; text-align: justify; text-indent: 2em"
+          v-html="product?.[translator(`content`)]"
         ></p>
+        <!-- v-html="translateContent(item)" -->
       </div>
-      <div class="projects-id__images-wrapper">
-        <!-- <h1 class="projects-id__images-title">{{ $t("photo") }}</h1> -->
-        <div class="projects-id__images-row" ref="images">
+      <!-- <div class="products__images-wrapper">
+        <h1 class="products__images-title">{{ $t("imagesText") }}</h1>
+        <div class="products__images-row" ref="images">
           <div
-            class="projects-id__images-img"
-            v-for="photo in project?.images"
+            class="products__images-img"
+            v-for="photo in product?.images"
             :key="photo"
-            @click="openModal(`${imageURL}${photo}`)"
           >
             <img :src="`${imageURL}${photo}`" alt="" />
           </div>
         </div>
-      </div>
-      <ImagePreviewModal
-        :imageUrl="selectedImage"
-        :isVisible="isModalVisible"
-        @close="closeModal"
-      />
+      </div> -->
     </div>
   </div>
 </template>
 
 <script>
-import { GET_PROJECT_ONE } from '@/api/home.api';
+import { GET_PRODUCTS_ONE } from '@/api/home.api';
 import translate from '@/mixins/translate';
 import { mapGetters } from 'vuex';
-import ImagePreviewModal from '~/components/ImagePreviewModal.vue';
 
 export default {
-  components: {
-    ImagePreviewModal,
-  },
   mixins: [translate],
   computed: {
     ...mapGetters(['imageURL']),
   },
   data() {
     return {
-      project: {
+      product: {
         images: {
           type: Array,
           default: () => [],
         },
       },
-      isModalVisible: false,
-      selectedImage: '',
     };
   },
   async mounted() {
-    await this.fetchProject();
+    await this.fetchProducts();
     if (this.$refs.aos) {
       const options =
         {
@@ -131,34 +96,24 @@ export default {
   },
 
   methods: {
-    async fetchProject() {
+    async fetchProducts() {
       try {
-        const { data, statusCode } = await GET_PROJECT_ONE({
-          data: {
-            projectId: this.$route.params.id,
-          },
+        const { data, statusCode } = await GET_PRODUCTS_ONE({
+          slug: this.$route.params.slug,
         });
         if (statusCode) {
-          this.project = data || {};
+          this.product = data || {};
         }
       } catch (error) {
         console.error(error);
       }
-    },
-    openModal(imageUrl) {
-      this.selectedImage = imageUrl;
-      this.isModalVisible = true;
-    },
-    closeModal() {
-      this.isModalVisible = false;
-      this.selectedImage = '';
     },
   },
 };
 </script>
 
 <style lang="scss" scoped>
-.projects-id {
+.products {
   padding: 120px 0;
   @media (max-width: 767px) {
     padding: 30px 0;
@@ -198,22 +153,18 @@ export default {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    max-width: 980px;
     margin-bottom: 30px;
   }
 
   &__project-image {
-    flex: 0 0 25%;
-    height: 155px;
+    max-width: 180px;
+    height: 100px;
     img {
       width: 100%;
       height: 100%;
-      object-fit: cover;
+      object-fit: contain;
       object-position: center;
-      border-radius: 4px;
-    }
-    @media (max-width: 479px) {
-      flex: 0 0 50%;
-      height: 130px;
     }
   }
 
@@ -221,7 +172,6 @@ export default {
     display: flex;
     flex-direction: column;
     gap: 8px;
-    width: 750px;
   }
 
   &__project-text {
@@ -229,13 +179,11 @@ export default {
     font-size: 16px;
     font-weight: 400;
     line-height: normal;
-    text-transform: initial;
+    text-transform: capitalize;
   }
 
   &__project-span {
     margin-right: 4px;
-    font-weight: 600;
-    text-transform: initial;
   }
 
   &__description-wrapper {
@@ -247,7 +195,7 @@ export default {
     font-size: 30px;
     font-weight: 400;
     letter-spacing: 0.45px;
-    // text-transform: capitalize;
+    text-transform: capitalize;
     padding-bottom: 7px;
     position: relative;
     display: inline-block;
@@ -276,12 +224,16 @@ export default {
     }
   }
 
+  .inner_description > ul {
+    list-style-type: unset !important;
+  }
+
   &__description-description {
+    list-style-type: unset;
     color: #000;
     font-size: 17px;
-    text-indent: 2em;
     font-weight: 500;
-    line-height: 2em;
+    line-height: normal;
     @media (max-width: 767px) {
       font-size: 15px;
     }
@@ -332,16 +284,13 @@ export default {
     overflow-x: auto;
     max-width: 100%;
     padding-bottom: 10px;
-
-    @media (min-width: 767px) {
+    transition: 1s all;
+    transform: translateY(120px);
+    opacity: 0;
+    &.aos {
+      opacity: 1;
+      transform: translateY(0px);
       transition: 1s all;
-      transform: translateY(120px);
-      opacity: 0;
-      &.aos {
-        opacity: 1;
-        transform: translateY(0px);
-        transition: 1s all;
-      }
     }
     @media (max-width: 479px) {
       gap: 16px;
@@ -352,8 +301,10 @@ export default {
     flex: 0 0 25%;
     height: 155px;
     img {
-      width: 100%;
-      height: 100%;
+      max-width: 100%;
+      width: auto;
+      max-height: 100%;
+      height: auto;
       object-fit: cover;
       object-position: center;
       border-radius: 4px;

--- a/client/pages/products-services/index.vue
+++ b/client/pages/products-services/index.vue
@@ -11,11 +11,11 @@
       </div>
       <div class="services__row" ref="images">
         <div class="services__item" v-for="item in items" :key="item.id">
-          <!-- @click="$router.push(localeLocation(`/products-services/${item?.id}`))" -->
+          <!-- @click="$router.push(localeLocation(`/products-services/${item?.slug}`))" -->
           <!-- <div class="services__image">
             <img :src="`${imageURL}${item?.images[0]}`" alt="" />
           </div> -->
-          <a :href="`/products-services/${item?.id}`">
+          <a :href="`/products-services/${item?.slug}`">
             <div class="services__content">
               <div class="services__content-logo">
                 <img :src="`${imageURL}${item?.logo}`" alt="" />

--- a/client/pages/projects/index.vue
+++ b/client/pages/projects/index.vue
@@ -11,8 +11,8 @@
       </div>
       <div class="projects__items" ref="images">
         <div v-for="project in projects.rows" :key="project.projectId" class="projects-item">
-          <!-- @click="openInNewTab(project.projectId)" -->
-          <a :href="`projects/${project.projectId}`" class="projects-item">
+          <!-- @click="openInNewTab(project.slug)" -->
+          <a :href="`${project.slug}`" class="projects-item">
             <div class="projects-item__image">
               <img :src="`${imageURL}${project?.cover}`" alt="" />
             </div>
@@ -81,8 +81,8 @@ export default {
   },
 
   methods: {
-    openInNewTab(projectId) {
-      this.$router.push(`/projects/${projectId}`);
+    openInNewTab(slug) {
+      this.$router.push(`/projects/${slug}`);
     },
 
     async fetchProjects() {

--- a/server/src/app.controller.ts
+++ b/server/src/app.controller.ts
@@ -170,10 +170,11 @@ export class AppController {
     return this.appService.removeService({ id: serviceId });
   }
 
-  @Post('services/find/:serviceId')
+  @Post('services/find/:slug')
   findService(
-    /* @Body() dto: findServiceDto*/ @Param('serviceId') serviceId: string,
+    /* @Body() dto: findServiceDto*/ @Param('slug') slug: string,
   ) {
+    const serviceId = slug.split('_').pop();
     return this.appService.findOneService({ id: serviceId });
   }
 

--- a/server/src/app.service.ts
+++ b/server/src/app.service.ts
@@ -18,6 +18,7 @@ import { PrismaService } from './prisma/prisma.service';
 import * as nodemailer from 'nodemailer';
 import { PaginationRequest } from './common/interfaces';
 import { TaglineService } from './tagline/tagline.service';
+import { slugWithId } from 'src/utils';
 @Injectable()
 export class AppService {
   constructor(
@@ -198,7 +199,20 @@ export class AppService {
         take: pagination.limit,
         skip: pagination.skip,
       });
-      return { mainNews, news };
+      if (mainNews) {
+        mainNews = {
+          ...mainNews,
+          slug: slugWithId(
+            mainNews.titleEn || mainNews.titleTm || mainNews.titleRu,
+            mainNews.newsId,
+          ),
+        };
+      }
+      const newsWithSlug = news.map((row) => ({
+        ...row,
+        slug: slugWithId(row.titleEn || row.titleTm || row.titleRu, row.newsId),
+      }));
+      return { mainNews, news: newsWithSlug };
     } catch (err) {
       throw new HttpException(
         {
@@ -226,7 +240,11 @@ export class AppService {
         orderBy: { workDate: 'desc' },
         take: 6,
       });
-      return projects;
+      const projectsWithSlug = projects.map((row) => ({
+        ...row,
+        slug: slugWithId(row.nameEn || row.nameTm || row.nameRu, row.projectId),
+      }));
+      return projectsWithSlug;
     } catch (err) {
       throw new HttpException(
         {
@@ -369,7 +387,15 @@ export class AppService {
         where: { catalogType: 'productservices' },
         select: { catalogType: true, fileUrl: true },
       });
-      return { products, services, catalog };
+      const productsWithSlug = products.map((row) => ({
+        ...row,
+        slug: slugWithId(row.nameEn || row.nameTm || row.nameRu, row.id),
+      }));
+      const servicesWithSlug = services.map((row) => ({
+        ...row,
+        slug: slugWithId(row.nameEn || row.nameTm || row.nameRu, row.id),
+      }));
+      return { products: productsWithSlug, services: servicesWithSlug, catalog };
     } catch (err) {
       throw new HttpException(
         {
@@ -1252,7 +1278,11 @@ export class AppService {
         skip: skip,
         orderBy: [{ priority: 'asc' }, { createdAt: 'desc' }],
       });
-      return { count, pageCount, rows };
+      const rowsWithSlug = rows.map((row) => ({
+        ...row,
+        slug: slugWithId(row.nameEn || row.nameTm || row.nameRu, row.id),
+      }));
+      return { count, pageCount, rows: rowsWithSlug };
     } catch (err) {
       throw new HttpException(
         {

--- a/server/src/news/news.controller.ts
+++ b/server/src/news/news.controller.ts
@@ -38,8 +38,9 @@ export class NewsController {
   }
 
   @UseGuards(FackeGuard)
-  @Get('/one/:newsId')
-  fetchOneNews(@Param('newsId') newsId: string, @Req() req: RequestWithUser) {
+  @Get('/one/:slug')
+  fetchOneNews(@Param('slug') slug: string, @Req() req: RequestWithUser) {
+    const newsId = slug.split('_').pop();
     return this.newsService.fetchOneNews(newsId, req.id);
   }
 

--- a/server/src/news/news.service.ts
+++ b/server/src/news/news.service.ts
@@ -1,5 +1,6 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
+import { slugWithId } from 'src/utils';
 import { UpsertNewsDto, changeIsMainDto, changePriorityDto } from './news.dto';
 import { PaginationRequest } from '../common/interfaces';
 
@@ -139,7 +140,11 @@ export class NewsService {
           skip: pagination.skip,
           orderBy: [{ [`${pagination.order_by}`]: pagination.order_direction }],
         });
-        return { count, pageCount, rows };
+        const rowsWithSlug = rows.map((row) => ({
+          ...row,
+          slug: slugWithId(row.titleEn || row.titleTm || row.titleRu, row.newsId),
+        }));
+        return { count, pageCount, rows: rowsWithSlug };
       }
       // request send by client
       const count: number = await this.prismaService.news.count({
@@ -164,7 +169,11 @@ export class NewsService {
         skip: pagination.skip,
         orderBy: [{ [`${pagination.order_by}`]: pagination.order_direction }],
       });
-      return { count, pageCount, rows };
+      const rowsWithSlug = rows.map((row) => ({
+        ...row,
+        slug: slugWithId(row.titleEn || row.titleTm || row.titleRu, row.newsId),
+      }));
+      return { count, pageCount, rows: rowsWithSlug };
     } catch (err) {
       throw new HttpException(
         {

--- a/server/src/projects/projects.controller.ts
+++ b/server/src/projects/projects.controller.ts
@@ -39,8 +39,9 @@ export class ProjectsController {
     return this.projectsService.fetchProjects(dto, req?.id ? req?.id : '');
   }
 
-  @Post('one/:projectId') // only for admin panel
-  fetchOneProject(@Param('projectId') projectId: string) {
+  @Post('one/:slug') // only for admin panel
+  fetchOneProject(@Param('slug') slug: string) {
+    const projectId = slug.split('_').pop();
     return this.projectsService.fetchOneProject(projectId);
   }
 

--- a/server/src/projects/projects.service.ts
+++ b/server/src/projects/projects.service.ts
@@ -1,5 +1,6 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
+import { slugWithId } from 'src/utils';
 import {
   fetchCategoryProjectsDto,
   fetchProjectsDto,
@@ -163,7 +164,11 @@ export class ProjectsService {
         // orderBy: [{ priority: 'asc' }, { workDate: 'desc' }],
         orderBy: [{ workDate: 'desc' }],
       });
-      return { count, pageCount, rows };
+      const rowsWithSlug = rows.map((row) => ({
+        ...row,
+        slug: slugWithId(row.nameEn || row.nameTm || row.nameRu, row.projectId),
+      }));
+      return { count, pageCount, rows: rowsWithSlug };
     } catch (err) {
       throw new HttpException(
         {

--- a/server/src/utils/index.ts
+++ b/server/src/utils/index.ts
@@ -1,3 +1,4 @@
 export { FileHelper } from './file-delete.util';
 export { RequestWithUser } from './request-with-user';
 export { responseInterceptor } from './response.interceptor';
+export { slugify, slugWithId } from './slug.util';

--- a/server/src/utils/slug.util.ts
+++ b/server/src/utils/slug.util.ts
@@ -1,0 +1,14 @@
+export function slugify(text: string): string {
+  return text
+    .toString()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036F]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function slugWithId(text: string, id: string): string {
+  return `${slugify(text)}_${id}`;
+}


### PR DESCRIPTION
## Summary
- Generate slug strings for news, projects, and product/service items
- Accept slug-based URLs in find-one endpoints and client pages
- Update listings and API utilities to expose and use slug paths

## Testing
- `cd server && npm test` *(fails: jest not found)*
- `cd ../client && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5ac88a1248325aa3567c1241823e3